### PR TITLE
Update caphost delay with managed identity id

### DIFF
--- a/infra/bicep/main-advanced-azdo.bicepparam
+++ b/infra/bicep/main-advanced-azdo.bicepparam
@@ -50,22 +50,24 @@ param makeWebAppsPublic = empty('#{makeWebAppsPublic}#') ? false : toLower('#{ma
 param existingVnetName = empty('#{EXISTING_VNET_NAME}#') ? null : '#{EXISTING_VNET_NAME}#'
 param existingVnetResourceGroupName = empty('#{EXISTING_VNET_RESOURCE_GROUP_NAME}#') ? null : '#{EXISTING_VNET_RESOURCE_GROUP_NAME}#'
 
+param existingCosmosAccountName = empty('#{EXISTING_COSMOS_ACCOUNT_NAME}#') ? null : '#{EXISTING_COSMOS_ACCOUNT_NAME}#'
+
 param vm_username = empty('#{VM_USERNAME}#') ? null : '#{VM_USERNAME}#' // This is the username for the admin user of jumpboxvm
 param vm_password = empty('#{VM_PASSWORD}#') ? null : '#{VM_PASSWORD}#' // This is the password for the admin user of jumpboxvm
 param vm_name = empty('#{VM_NAME}#') ? null : '#{VM_NAME}#' // optional Jumpbox VM name - otherwise created by resourceNames.bicep
 param myIpAddress = empty('#{MY_IP_ADDRESS}#') ? null : '#{MY_IP_ADDRESS}#'
 
 param deployAPIM = empty('#{deployAPIM}#') ? false : toLower('#{deployAPIM}#') == 'true'
-// Should we deploy the API Management service?
 param deployUIApp = empty('#{deployUIApp}#') ? false : toLower('#{deployUIApp}#') == 'true'
-// Should we deploy the UI app?
 param vnetPrefix = empty('#{VNET_PREFIX}#') ? null : '#{VNET_PREFIX}#'
+
+param addCapHostDelayScripts = empty('#{addCapHostDelayScripts}#') ? true : toLower('#{addCapHostDelayScripts}#') == 'true'
 
 // applications
 param uiImageName = empty('#{UI_IMAGE_NAME}#') ? null : '#{UI_IMAGE_NAME}#'
 
-// only for Microsoft internal deployments
-param mockUserUpn = empty('#{MOCK_USER_UPN}#') ? false : toLower('#{MOCK_USER_UPN}#') == 'true' // Mock user UPN for testing purposes
+// // only for Microsoft internal deployments
+// param mockUserUpn = empty('#{MOCK_USER_UPN}#') ? false : toLower('#{MOCK_USER_UPN}#') == 'true' // Mock user UPN for testing purposes
 
 // use consumption for non-customer deployments
 param containerAppEnvironmentWorkloadProfiles = [

--- a/infra/bicep/main-advanced.bicep
+++ b/infra/bicep/main-advanced.bicep
@@ -157,8 +157,8 @@ param apimBaseUrl string = ''
 param apimAccessUrl string = ''
 @secure()
 param apimAccessKey string = ''
-@description('When set to true, UPN received from the authentication will be mocked to a fixed value')
-param mockUserUpn bool = false
+// @description('When set to true, UPN received from the authentication will be mocked to a fixed value')
+// param mockUserUpn bool = false
 
 // --------------------------------------------------------------------------------------------------------------
 // Application Gateway Parameters
@@ -217,6 +217,12 @@ param deployUIApp bool = false
 @description('Should we deploy a Document Intelligence?')
 param deployDocumentIntelligence bool = false
 
+@description('Add scripts to put a delay before the CAP Host deploy steps')
+param addCapHostDelayScripts bool = true
+
+@description('Name of existing Cosmos account to reuse?')
+param existingCosmosAccountName string = ''
+
 @description('Global Region where the resources will be deployed, e.g. AM (America), EM (EMEA), AP (APAC), CH (China)')
 param regionCode string = 'US'
 
@@ -269,6 +275,9 @@ var deployEntraClientSecrets = !(empty(entraClientId) || empty(entraClientSecret
 var deployContainerRegistry = deployAPIApp || deployUIApp
 var deployCAEnvironment = deployAPIApp || deployUIApp
 var deployVirtualMachine = !empty(vm_username) && !empty(vm_password)
+
+// Should we deploy a Cosmos or reuse existing?
+var deployCosmos = !empty(existingCosmosAccountName) ? false : true
 
 // --------------------------------------------------------------------------------------------------------------
 // -- Generate Resource Names -----------------------------------------------------------------------------------
@@ -547,7 +556,8 @@ var sessionsContainerArray = [
 module cosmos './modules/database/cosmosdb.bicep' = {
   name: 'cosmos${deploymentSuffix}'
   params: {
-    accountName: resourceNames.outputs.cosmosName
+    accountName: deployCosmos ? resourceNames.outputs.cosmosName : ''
+    existingAccountName: deployCosmos ? '' : existingCosmosAccountName
     databaseName: uiDatabaseName
     sessionsDatabaseName: sessionsDatabaseName
     sessionContainerArray: sessionsContainerArray
@@ -714,6 +724,7 @@ module aiProject './modules/ai/ai-project-with-caphost.bicep' = {
     projectNo: 1
     aiDependencies: aiDependencies
     managedIdentityId: identity.outputs.managedIdentityId
+    addCapHostDelayScripts: addCapHostDelayScripts
   }
 }
 

--- a/infra/bicep/main-advanced.bicep
+++ b/infra/bicep/main-advanced.bicep
@@ -713,6 +713,7 @@ module aiProject './modules/ai/ai-project-with-caphost.bicep' = {
     location: location
     projectNo: 1
     aiDependencies: aiDependencies
+    managedIdentityId: identity.outputs.managedIdentityId
   }
 }
 

--- a/infra/bicep/main-basic-azdo.bicepparam
+++ b/infra/bicep/main-basic-azdo.bicepparam
@@ -46,12 +46,16 @@ param addRoleAssignments = empty('#{addRoleAssignments}#') ? false : toLower('#{
 param publicAccessEnabled = true
 param makeWebAppsPublic = true
 
+param existingCosmosAccountName = empty('#{EXISTING_COSMOS_ACCOUNT_NAME}#') ? null : '#{EXISTING_COSMOS_ACCOUNT_NAME}#'
+
 param deployAPIM = empty('#{deployAPIM}#') ? false : toLower('#{deployAPIM}#') == 'true'
 param deployUIApp = empty('#{deployUIApp}#') ? false : toLower('#{deployUIApp}#') == 'true'
 param uiImageName = empty('#{UI_IMAGE_NAME}#') ? null : '#{UI_IMAGE_NAME}#'
 
-// only for Microsoft internal deployments
-param mockUserUpn = empty('#{MOCK_USER_UPN}#') ? false : toLower('#{MOCK_USER_UPN}#') == 'true' // Mock user UPN for testing purposes
+param addCapHostDelayScripts = empty('#{addCapHostDelayScripts}#') ? true : toLower('#{addCapHostDelayScripts}#') == 'true'
+
+// // only for Microsoft internal deployments
+// param mockUserUpn = empty('#{MOCK_USER_UPN}#') ? false : toLower('#{MOCK_USER_UPN}#') == 'true' // Mock user UPN for testing purposes
 
 // use consumption for non-customer deployments
 param containerAppEnvironmentWorkloadProfiles = [

--- a/infra/bicep/main-basic.bicep
+++ b/infra/bicep/main-basic.bicep
@@ -119,8 +119,8 @@ param apimBaseUrl string = ''
 param apimAccessUrl string = ''
 @secure()
 param apimAccessKey string = ''
-@description('When set to true, UPN received from the authentication will be mocked to a fixed value')
-param mockUserUpn bool = false
+// @description('When set to true, UPN received from the authentication will be mocked to a fixed value')
+// param mockUserUpn bool = false
 
 // --------------------------------------------------------------------------------------------------------------
 // Existing images
@@ -149,6 +149,12 @@ param deployUIApp bool = false
 @description('Should we deploy a Document Intelligence?')
 param deployDocumentIntelligence bool = false
 
+@description('Add scripts to put a delay before the CAP Host deploy steps')
+param addCapHostDelayScripts bool = true
+
+@description('Name of existing Cosmos account to reuse?')
+param existingCosmosAccountName string = ''
+
 @description('Global Region where the resources will be deployed, e.g. AM (America), EM (EMEA), AP (APAC), CH (China)')
 param regionCode string = 'US'
 
@@ -161,10 +167,10 @@ param logRetentionInDays int = 365
 // --------------------------------------------------------------------------------------------------------------
 // Additional Tags that may be included or not
 // --------------------------------------------------------------------------------------------------------------
-param businessOwnerTag string = 'UNKNOWN'
-param applicationOwnerTag string = 'UNKNOWN'
 param createdByTag string = 'UNKNOWN'
-param costCenterTag string = 'UNKNOWN'
+// param businessOwnerTag string = 'UNKNOWN'
+// param applicationOwnerTag string = 'UNKNOWN'
+// param costCenterTag string = 'UNKNOWN'
 
 // --------------------------------------------------------------------------------------------------------------
 // A variable masquerading as a parameter to allow for dynamic value assignment in Bicep
@@ -187,9 +193,9 @@ var tags = {
   'created-by': createdByTag
   'application-name': applicationName
   'environment-name': environmentName
-  'application-owner': applicationOwnerTag
-  'business-owner': businessOwnerTag
-  'cost-center': costCenterTag
+  // 'application-owner': applicationOwnerTag
+  // 'business-owner': businessOwnerTag
+  // 'cost-center': costCenterTag
 }
 
 // Run a script to dedupe the KeyVault secrets -- this fails on private networks right now so turn if off for them
@@ -200,6 +206,9 @@ var deployEntraClientSecrets = !(empty(entraClientId) || empty(entraClientSecret
 
 var deployContainerRegistry = deployAPIApp || deployUIApp
 var deployCAEnvironment = deployAPIApp || deployUIApp
+
+// Should we deploy a Cosmos or reuse existing?
+var deployCosmos = !empty(existingCosmosAccountName) ? false : true
 
 // --------------------------------------------------------------------------------------------------------------
 // -- Generate Resource Names -----------------------------------------------------------------------------------
@@ -409,7 +418,8 @@ var sessionsContainerArray = [
 module cosmos './modules/database/cosmosdb.bicep' = {
   name: 'cosmos${deploymentSuffix}'
   params: {
-    accountName: resourceNames.outputs.cosmosName
+    accountName: deployCosmos ? resourceNames.outputs.cosmosName : ''
+    existingAccountName: deployCosmos ? '' : existingCosmosAccountName
     databaseName: uiDatabaseName
     sessionsDatabaseName: sessionsDatabaseName
     sessionContainerArray: sessionsContainerArray
@@ -568,6 +578,7 @@ module aiProject './modules/ai/ai-project-with-caphost.bicep' = {
     createHubCapabilityHost: true   // this is required for non-vnet injected
     aiDependencies: aiDependencies
     managedIdentityId: identity.outputs.managedIdentityId
+    addCapHostDelayScripts: addCapHostDelayScripts
   }
 }
 

--- a/infra/bicep/main-basic.bicep
+++ b/infra/bicep/main-basic.bicep
@@ -567,6 +567,7 @@ module aiProject './modules/ai/ai-project-with-caphost.bicep' = {
     projectNo: 1
     createHubCapabilityHost: true   // this is required for non-vnet injected
     aiDependencies: aiDependencies
+    managedIdentityId: identity.outputs.managedIdentityId
   }
 }
 

--- a/infra/bicep/main-project.bicep
+++ b/infra/bicep/main-project.bicep
@@ -44,6 +44,8 @@ param publicAccessEnabled bool = false
 param appendResourceTokens bool = false
 @description('Create DNS Zones?')
 param createDnsZones bool = true
+@description('Add scripts to put a delay before the CAP Host deploy steps')
+param addCapHostDelayScripts bool = true
 
 // --------------------------------------------------------------------------------------------------------------
 // Virtual machine jumpbox
@@ -79,10 +81,10 @@ param runDateTime string = utcNow()
 // --------------------------------------------------------------------------------------------------------------
 // Additional Tags that may be included or not
 // --------------------------------------------------------------------------------------------------------------
-param businessOwnerTag string = 'UNKNOWN'
-param applicationOwnerTag string = 'UNKNOWN'
 param createdByTag string = 'UNKNOWN'
-param costCenterTag string = 'UNKNOWN'
+// param businessOwnerTag string = 'UNKNOWN'
+// param applicationOwnerTag string = 'UNKNOWN'
+// param costCenterTag string = 'UNKNOWN'
 
 // --------------------------------------------------------------------------------------------------------------
 // -- Variables -------------------------------------------------------------------------------------------------
@@ -95,9 +97,9 @@ var tags = {
   'creation-date': take(runDateTime, 8)
   'created-by': createdByTag
   'environment-name': environmentName
-  'application-owner': applicationOwnerTag
-  'business-owner': businessOwnerTag
-  'cost-center': costCenterTag
+  // 'application-owner': applicationOwnerTag
+  // 'business-owner': businessOwnerTag
+  // 'cost-center': costCenterTag
 }
 
 var deployVirtualMachine = !empty(vm_username) && !empty(vm_password)
@@ -342,6 +344,7 @@ module aiProject1 './modules/ai/ai-project-with-caphost.bicep' = {
     projectNo: projectNumber
     aiDependencies: aiDependecies
     managedIdentityId: identity.outputs.managedIdentityId
+    addCapHostDelayScripts: addCapHostDelayScripts
   }
   dependsOn: [allDnsZones]
 }

--- a/infra/bicep/main-project.bicep
+++ b/infra/bicep/main-project.bicep
@@ -341,6 +341,7 @@ module aiProject1 './modules/ai/ai-project-with-caphost.bicep' = {
     location: location
     projectNo: projectNumber
     aiDependencies: aiDependecies
+    managedIdentityId: identity.outputs.managedIdentityId
   }
   dependsOn: [allDnsZones]
 }

--- a/infra/bicep/modules/ai/ai-project-with-caphost.bicep
+++ b/infra/bicep/modules/ai/ai-project-with-caphost.bicep
@@ -5,7 +5,7 @@ param aiDependencies types.aiDependenciesType
 param location string
 param foundryName string
 param createHubCapabilityHost bool = false
-param managedIdentityId string = ''
+// param managedIdentityId string = ''
 
 @description('The number of the AI project to create')
 @minValue(1)
@@ -24,7 +24,7 @@ module aiProject './ai-project.bicep' = {
     projectName: 'ai-project-${projectNo}'
     projectDescription: 'AI Project ${projectNo}'
     displayName: 'AI Project ${projectNo}'
-    managedIdentityId: null // Use System Assigned Identity
+    // managedIdentityId: null // Use System Assigned Identity
 
     aiSearchName: aiDependencies.aiSearch.name
     aiSearchServiceResourceGroupName: aiDependencies.aiSearch.resourceGroupName
@@ -41,6 +41,16 @@ module aiProject './ai-project.bicep' = {
 }
 
 // NOTE: using a wait script to ensure the project is fully deployed before proceeding with role assignments and connections
+// // this br/public:deployment-scripts/wait module has been deprecated...
+// module waitForProjectScript 'br/public:deployment-scripts/wait:1.1.1' = {
+//   name: 'waitForProjectScript-${projectNo}'
+//   dependsOn: [aiProject]
+//   params: {
+//     waitSeconds: 90
+//     location: resourceGroup().location
+//   }
+// }
+// fails because it's trying to use key based access to the storage account
 module waitForProjectScript 'waitDeploymentScript.bicep' = {
   name: 'waitForProjectScript-${projectNo}'
   dependsOn: [aiProject]
@@ -48,7 +58,7 @@ module waitForProjectScript 'waitDeploymentScript.bicep' = {
     name: 'script-wait-proj-${projectNo}'
     location: location
     seconds: 90
-    userManagedIdentityId: managedIdentityId
+    // userManagedIdentityId: managedIdentityId
   }
 }
 
@@ -108,6 +118,16 @@ module addProjectCapabilityHost 'add-project-capability-host.bicep' = {
 }
 
 // NOTE: using a wait script to ensure all connections are established before finishing the capability host
+// this br/public:deployment-scripts/wait module has been deprecated...
+// module waitForConnectionsScript 'br/public:deployment-scripts/wait:1.1.1' = {
+//   name:  'waitForConnectionsScript-${projectNo}'
+//   dependsOn: [addProjectCapabilityHost]
+//   params: {
+//     waitSeconds: 90
+//     location: resourceGroup().location
+//   }
+// }
+// but this fails because it's trying to use key based access to the storage account
 module waitForConnectionsScript 'waitDeploymentScript.bicep' = {
   name: 'waitForConnectionsScript-${projectNo}'
   dependsOn: [addProjectCapabilityHost]
@@ -115,7 +135,7 @@ module waitForConnectionsScript 'waitDeploymentScript.bicep' = {
     name: 'script-wait-connections-${projectNo}'
     location: location
     seconds: 90
-    userManagedIdentityId: managedIdentityId
+    // userManagedIdentityId: managedIdentityId
   }
 }
 

--- a/infra/bicep/modules/ai/ai-project-with-caphost.bicep
+++ b/infra/bicep/modules/ai/ai-project-with-caphost.bicep
@@ -5,6 +5,7 @@ param aiDependencies types.aiDependenciesType
 param location string
 param foundryName string
 param createHubCapabilityHost bool = false
+param managedIdentityId string = ''
 
 @description('The number of the AI project to create')
 @minValue(1)
@@ -47,6 +48,7 @@ module waitForProjectScript 'waitDeploymentScript.bicep' = {
     name: 'script-wait-proj-${projectNo}'
     location: location
     seconds: 90
+    userManagedIdentityId: managedIdentityId
   }
 }
 
@@ -113,6 +115,7 @@ module waitForConnectionsScript 'waitDeploymentScript.bicep' = {
     name: 'script-wait-connections-${projectNo}'
     location: location
     seconds: 90
+    userManagedIdentityId: managedIdentityId
   }
 }
 

--- a/infra/bicep/modules/ai/ai-project-with-caphost.bicep
+++ b/infra/bicep/modules/ai/ai-project-with-caphost.bicep
@@ -5,7 +5,8 @@ param aiDependencies types.aiDependenciesType
 param location string
 param foundryName string
 param createHubCapabilityHost bool = false
-// param managedIdentityId string = ''
+param managedIdentityId string = ''
+param addCapHostDelayScripts bool = true
 
 @description('The number of the AI project to create')
 @minValue(1)
@@ -24,7 +25,7 @@ module aiProject './ai-project.bicep' = {
     projectName: 'ai-project-${projectNo}'
     projectDescription: 'AI Project ${projectNo}'
     displayName: 'AI Project ${projectNo}'
-    // managedIdentityId: null // Use System Assigned Identity
+    managedIdentityId: null // Use System Assigned Identity
 
     aiSearchName: aiDependencies.aiSearch.name
     aiSearchServiceResourceGroupName: aiDependencies.aiSearch.resourceGroupName
@@ -58,7 +59,8 @@ module waitForProjectScript 'waitDeploymentScript.bicep' = {
     name: 'script-wait-proj-${projectNo}'
     location: location
     seconds: 90
-    // userManagedIdentityId: managedIdentityId
+    userManagedIdentityId: managedIdentityId
+    addCapHostDelayScripts: addCapHostDelayScripts
   }
 }
 
@@ -135,7 +137,8 @@ module waitForConnectionsScript 'waitDeploymentScript.bicep' = {
     name: 'script-wait-connections-${projectNo}'
     location: location
     seconds: 90
-    // userManagedIdentityId: managedIdentityId
+    userManagedIdentityId: managedIdentityId
+    addCapHostDelayScripts: addCapHostDelayScripts
   }
 }
 

--- a/infra/bicep/modules/ai/waitDeploymentScript.bicep
+++ b/infra/bicep/modules/ai/waitDeploymentScript.bicep
@@ -7,15 +7,24 @@ param location string
 @description('Required. Sleep/wait time for the deployment script in seconds.')
 param seconds int
 
+param utcValue string = utcNow()
+
+param userManagedIdentityId string = ''
+
 resource waitScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: name
   location: location
   kind: 'AzurePowerShell'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${ userManagedIdentityId }': {} }
+  }
   properties: {
     azPowerShellVersion: '11.0'
-    scriptContent: 'Write-Host "Waiting for ${seconds} seconds..." ; Start-Sleep -Seconds ${seconds}; Write-Host "Wait complete."'
+    forceUpdateTag: utcValue
+    retentionInterval: 'PT1H'
     timeout: 'P1D'
-    cleanupPreference: 'Always'
-    retentionInterval: 'P1D'
+    cleanupPreference: 'Always' // cleanupPreference: 'OnSuccess' or 'Always'
+    scriptContent: 'Write-Host "Waiting for ${seconds} seconds..." ; Start-Sleep -Seconds ${seconds}; Write-Host "Wait complete."'
   }
 }

--- a/infra/bicep/modules/ai/waitDeploymentScript.bicep
+++ b/infra/bicep/modules/ai/waitDeploymentScript.bicep
@@ -9,16 +9,16 @@ param seconds int
 
 param utcValue string = utcNow()
 
-param userManagedIdentityId string = ''
+//param userManagedIdentityId string = ''
 
 resource waitScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: name
   location: location
   kind: 'AzurePowerShell'
-  identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: { '${ userManagedIdentityId }': {} }
-  }
+  // identity: {
+  //   type: 'UserAssigned'
+  //   userAssignedIdentities: { '${ userManagedIdentityId }': {} }
+  // }
   properties: {
     azPowerShellVersion: '11.0'
     forceUpdateTag: utcValue

--- a/infra/bicep/modules/ai/waitDeploymentScript.bicep
+++ b/infra/bicep/modules/ai/waitDeploymentScript.bicep
@@ -9,17 +9,21 @@ param seconds int
 
 param utcValue string = utcNow()
 
-//param userManagedIdentityId string = ''
+param userManagedIdentityId string = ''
+param addCapHostDelayScripts bool = true
+// param storageAccountName string = ''
+// param storageAccountAccessKey string = ''
 
-resource waitScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+resource waitScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = if (addCapHostDelayScripts) {
   name: name
   location: location
   kind: 'AzurePowerShell'
-  // identity: {
-  //   type: 'UserAssigned'
-  //   userAssignedIdentities: { '${ userManagedIdentityId }': {} }
-  // }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${ userManagedIdentityId }': {} }
+  }
   properties: {
+    // storageAccountSettings: { storageAccountName: storageAccountName, storageAccountAccessKey: storageAccountAccessKey }  Note: this doesn't work without the access key...
     azPowerShellVersion: '11.0'
     forceUpdateTag: utcValue
     retentionInterval: 'PT1H'

--- a/infra/bicep/modules/security/keyvault-list-secret-names.bicep
+++ b/infra/bicep/modules/security/keyvault-list-secret-names.bicep
@@ -17,7 +17,7 @@ resource getKeyVaultSecretNames 'Microsoft.Resources/deploymentScripts@2023-08-0
     userAssignedIdentities: { '${ userManagedIdentityId }': {} }
   }
   properties: {
-    azPowerShellVersion: '8.1'
+    azPowerShellVersion: '11.0'
     forceUpdateTag: utcValue
     retentionInterval: 'PT1H'
     timeout: 'PT5M'


### PR DESCRIPTION
This pull request introduces new parameters and logic to improve flexibility and control in the infrastructure Bicep templates, particularly around Cosmos DB usage and deployment script delays. It also cleans up some internal-use parameters and updates script execution identities and PowerShell versions. The most important changes are summarized below:

**Cosmos DB Deployment Flexibility:**

* Added a new parameter `existingCosmosAccountName` to allow reusing an existing Cosmos DB account instead of always deploying a new one. Logic and module parameters were updated to support this across both basic and advanced templates. [[1]](diffhunk://#diff-77c34166cdede06559e2b7858b861e06f1a6a87711ebbe5c35f9b2987e2dbf21R220-R225) [[2]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9R152-R157) [[3]](diffhunk://#diff-f2472760028b53cee0edbf38aec6c0f1e48e53b93917ac48c2858d11b3733e06R53-R70) [[4]](diffhunk://#diff-5edcebb3cc5fb5001cd9388f70a75a6860e89c610f5d028c997160c9af7d5606R49-R58) [[5]](diffhunk://#diff-77c34166cdede06559e2b7858b861e06f1a6a87711ebbe5c35f9b2987e2dbf21L550-R560) [[6]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9L412-R422) [[7]](diffhunk://#diff-77c34166cdede06559e2b7858b861e06f1a6a87711ebbe5c35f9b2987e2dbf21R279-R281) [[8]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9R210-R212)

**Deployment Script Delay Control:**

* Introduced the `addCapHostDelayScripts` parameter to control whether delay scripts are added before CAP Host deploy steps. This is now configurable in all relevant templates and passed through to the AI project modules. [[1]](diffhunk://#diff-77c34166cdede06559e2b7858b861e06f1a6a87711ebbe5c35f9b2987e2dbf21R220-R225) [[2]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9R152-R157) [[3]](diffhunk://#diff-ce88ca6bd4dd3d5c535fc9e630a26baf51b5ad5f18933ddd264775c51fe0b328R47-R48) [[4]](diffhunk://#diff-f2472760028b53cee0edbf38aec6c0f1e48e53b93917ac48c2858d11b3733e06R53-R70) [[5]](diffhunk://#diff-5edcebb3cc5fb5001cd9388f70a75a6860e89c610f5d028c997160c9af7d5606R49-R58) [[6]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR8-R9) [[7]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR45-R63) [[8]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR123-R141) [[9]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9R580-R581) [[10]](diffhunk://#diff-77c34166cdede06559e2b7858b861e06f1a6a87711ebbe5c35f9b2987e2dbf21R726-R727) [[11]](diffhunk://#diff-ce88ca6bd4dd3d5c535fc9e630a26baf51b5ad5f18933ddd264775c51fe0b328R346-R347) [[12]](diffhunk://#diff-bb8bced1e5411024407feb8abb79374301907f4d2c1bc3b583fc70bebeec73c0L10-R32)

**AI Project Module Enhancements:**

* Updated `ai-project-with-caphost.bicep` and its usage to accept a managed identity and the new delay script parameter, ensuring deployment scripts use user-assigned managed identities and can be toggled for delay. [[1]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR8-R9) [[2]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR45-R63) [[3]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR123-R141) [[4]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9R580-R581) [[5]](diffhunk://#diff-77c34166cdede06559e2b7858b861e06f1a6a87711ebbe5c35f9b2987e2dbf21R726-R727) [[6]](diffhunk://#diff-ce88ca6bd4dd3d5c535fc9e630a26baf51b5ad5f18933ddd264775c51fe0b328R346-R347) [[7]](diffhunk://#diff-bb8bced1e5411024407feb8abb79374301907f4d2c1bc3b583fc70bebeec73c0L10-R32)

**Tag Parameter Cleanup:**

* Commented out or removed parameters and tag assignments for `businessOwnerTag`, `applicationOwnerTag`, and `costCenterTag` in several templates, reducing unnecessary parameters for most deployments. [[1]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9L164-R173) [[2]](diffhunk://#diff-ce88ca6bd4dd3d5c535fc9e630a26baf51b5ad5f18933ddd264775c51fe0b328L82-R87) [[3]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9L190-R198) [[4]](diffhunk://#diff-ce88ca6bd4dd3d5c535fc9e630a26baf51b5ad5f18933ddd264775c51fe0b328L98-R102)

**Internal/Obsolete Parameter and Version Updates:**

* Commented out the `mockUserUpn` parameter (previously for internal testing) and updated the PowerShell version used in key vault secret listing scripts to 11.0 for improved compatibility and security. [[1]](diffhunk://#diff-77c34166cdede06559e2b7858b861e06f1a6a87711ebbe5c35f9b2987e2dbf21L160-R161) [[2]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9L122-R123) [[3]](diffhunk://#diff-f2472760028b53cee0edbf38aec6c0f1e48e53b93917ac48c2858d11b3733e06R53-R70) [[4]](diffhunk://#diff-5edcebb3cc5fb5001cd9388f70a75a6860e89c610f5d028c997160c9af7d5606R49-R58) [[5]](diffhunk://#diff-3ff037cc23e0066328ffc1bdcc35fb0006aa660068d9e70f9d31f0e2859de2f7L20-R20)

These changes collectively improve deployment flexibility, security, and maintainability across the infrastructure codebase.


This pull request updates the Bicep infrastructure modules to support passing a user-assigned managed identity to deployment scripts, enhancing security and enabling identity-based resource access during deployments. The main changes involve propagating a `managedIdentityId` parameter through relevant modules and configuring the deployment scripts to use this identity.

**Managed identity support for deployment scripts:**

* Added a new `managedIdentityId` parameter to the `ai-project-with-caphost.bicep` module and updated all parent modules (`main-basic.bicep`, `main-advanced.bicep`, `main-project.bicep`) to pass the managed identity output to it. [[1]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR8) [[2]](diffhunk://#diff-a69f8127178e542490ff5f8cd72239421f21d7c87cb593cb4fec71d271f614f9R570) [[3]](diffhunk://#diff-77c34166cdede06559e2b7858b861e06f1a6a87711ebbe5c35f9b2987e2dbf21R716) [[4]](diffhunk://#diff-ce88ca6bd4dd3d5c535fc9e630a26baf51b5ad5f18933ddd264775c51fe0b328R344)
* Updated the `waitDeploymentScript.bicep` module to accept a `userManagedIdentityId` parameter and configure the deployment script resource to use the provided user-assigned managed identity.
* Modified the `ai-project-with-caphost.bicep` module to pass the `managedIdentityId` to its child deployment scripts (`waitForProjectScript` and `waitForConnectionsScript`) via the `userManagedIdentityId` parameter. [[1]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR51) [[2]](diffhunk://#diff-86ffc2b29370cdfddf2f4a266d234324b8ef8a6f262c9ebf7ac0ffd72719f59fR118)